### PR TITLE
fix paged search examples

### DIFF
--- a/java/src/com/trendmicro/deepsecurity/docs/SearchExamples.java
+++ b/java/src/com/trendmicro/deepsecurity/docs/SearchExamples.java
@@ -144,7 +144,7 @@ public class SearchExamples {
 				Integer lastID = computers.getComputers().get(computers.getComputers().size() - 1).getID();
 				searchCriteria.setIdValue(Long.valueOf(lastID.toString()));
 			}
-		} while (found == pageSize.intValue()); // Exit loop when the page size is less than the maximum
+		} while (found > 0); // Exit loop when no computers are found
 	}
 
 	/**

--- a/javascript/lib/SearchExamples.js
+++ b/javascript/lib/SearchExamples.js
@@ -140,19 +140,21 @@ exports.pagedSearchComputers = function(api, apiVersion) {
     function getPageOfComputers(pageSearchOptions) {
       // Checks the search results to see if we're done
       function checkResults(searchResults) {
-        // Get the ID of the last computer found, and the number found
-        const lastID = searchResults.computers[searchResults.computers.length - 1].ID;
         const numFound = searchResults.computers.length;
+
+        // If the number found is zero we are done
+        if (numFound == 0) {
+          return results;
+        }
+
+        // Get the ID of the last computer found, and the number found
+        const lastID = searchResults.computers[numFound - 1].ID;
 
         // Uncomment to see the page details as they are obtained
         //console.log(`last ID:  ${lastID}; numfound: ${numFound}`);
 
         results.push(searchResults.computers);
 
-        // If the number found is less than the page size we are done
-        if (numFound < pageSize) {
-          return results;
-        }
         // Search filter for the next page of computers
         const nextSearchCriteria = new api.SearchCriteria();
         nextSearchCriteria.idValue = lastID;

--- a/python/src/search_examples.py
+++ b/python/src/search_examples.py
@@ -129,9 +129,6 @@ def paged_search_computers(api, configuration, api_version, api_exception):
             search_criteria.id_value = last_id
             print("Last ID: " + str(last_id), "Computers found: " + str(num_found))
 
-            if num_found != page_size:
-                break
-
         return paged_computers
 
     except api_exception as e:


### PR DESCRIPTION
Test for zero returned computers instead of page size
Handles case where invalid computers in the DB are not returned
in search results (causing page size to be less than expected)